### PR TITLE
support for multiple tokens #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You'll need to set an environment variable named `WIT_TOKEN` or specify your tok
 export WIT_TOKEN=[your token]
 ```
 
+Alternatively, you can pass the token to `Wit.message`.
+
 
 ## Usage
 

--- a/lib/wit.js
+++ b/lib/wit.js
@@ -7,12 +7,12 @@
   var Wit = {
     token: process.env.WIT_TOKEN,
 
-    message: function(message) {
+    message: function(message, token) {
       var deferred = Q.defer();
       var options = {
         host: 'api.wit.ai',
         path: '/message?q=' + encodeURIComponent(message),
-        headers: {Authorization: 'Bearer ' + Wit.token}
+        headers: {Authorization: 'Bearer ' + typeof token === 'string' ? token : Wit.token}
       };
 
       https.request(options, function(response) {


### PR DESCRIPTION
Currently you can only set the token globally (`Wit.token = token`). What if i want to use the _wit-node_ module in multiple places with different tokens?

An optional `token` parameter for the message method preferred over the global `Wit.token` would be nice.
