### PR TITLE
fixed a `module.exports` bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,1 @@
-(function () {
-  "use strict";
-
-  module.exports = {
-    wit: require('./lib/wit.js')
-  };
-}());
+module.exports = require('./lib/wit.js');


### PR DESCRIPTION
_wit-node_ can be used with `require('wit-node')` instead of `require('wit-node').wit`
